### PR TITLE
Add --protocol options for alignment with different data types (minimap2)

### DIFF
--- a/conf/test.config
+++ b/conf/test.config
@@ -21,6 +21,7 @@ params {
   flowcell = 'FLO-MIN106'
   kit = 'SQK-DCS108'
   barcode_kit = false
+  protocol = 'cDNA'
 
   // This variable is just for reference and isnt actually required for the tests
   // Files are downloaded and staged using the "GetTestData" process

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -207,7 +207,7 @@ Skip basecalling and demultiplexing step with Guppy
 
 ### `--protocol`
 
-Specifies the data type being inputted (DNA, cDNA or directRNA)
+Specifies the type of data that was sequenced i.e. "DNA", "cDNA" or "directRNA".
 
 ### `--stranded`
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -211,7 +211,7 @@ Specifies the type of data that was sequenced i.e. "DNA", "cDNA" or "directRNA".
 
 ### `--stranded`
 
-Specifies whether the inputted fastq files contain stranded data (default: false)
+Specifies if the data is strand-specific. Automatically activated when using --protocol directRNA (default: false)
 
 The specific command line arguments for `graphmap` and `minimap2` using `--protocol` and `--stranded` are specified below:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -222,7 +222,6 @@ When using `--protocol`/`--stranded` the following command-line arguments will b
 | `--protocol directRNA`       | -ax splice -uf -k14 | tba                |
 | `--protocol cDNA --stranded` | -ax splice -uf      | tba                |
 
-
 ### `--aligner`
 
 Specifies the aligner to use (available are: `graphmap` or `minimap2`)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -25,6 +25,8 @@
   * [`--gpu_cluster_options`](#--gpu_cluster_options)
   * [`--skip_demultiplexing`](#--skip_demultiplexing)
 * [Alignments](#alignments)
+  * [`--protocol`](#--protocol)
+  * [`--stranded`](#--stranded)
   * [`--aligner`](#--aligner)
   * [`--save_align_intermeds`](#--save_align_intermeds)
   * [`--skip_alignment`](#--skip_alignment)
@@ -202,6 +204,24 @@ Cluster options required to use GPU resources (e.g. '--part=gpu --gres=gpu:1')
 Skip basecalling and demultiplexing step with Guppy
 
 ## Alignment
+
+### `--protocol`
+
+Specifies the data type being inputted (DNA, cDNA or directRNA)
+
+### `--stranded`
+
+Specifies whether the inputted fastq files contain stranded data (default: false)
+
+The specific command line arguments for `graphmap` and `minimap2` using `--protocol` and `--stranded` are specified below:
+
+| `nanoseq` input              | `minimap2` presets  | `graphmap` presets |
+|------------------------------|---------------------|--------------------|
+| `--protocol DNA`             | -ax map-ont         | tba                |
+| `--protocol cDNA`            | -ax splice          | tba                |
+| `--protocol directRNA`       | -ax splice -uf -k14 | tba                |
+| `--protocol cDNA --stranded` | -ax splice -uf      | tba                |
+
 
 ### `--aligner`
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -213,7 +213,7 @@ Specifies the type of data that was sequenced i.e. "DNA", "cDNA" or "directRNA".
 
 Specifies if the data is strand-specific. Automatically activated when using --protocol directRNA (default: false)
 
-The specific command line arguments for `graphmap` and `minimap2` using `--protocol` and `--stranded` are specified below:
+When using `--protocol`/`--stranded` the following command-line arguments will be set for `minimap2` and `graphmap`:
 
 | `nanoseq` input              | `minimap2` presets  | `graphmap` presets |
 |------------------------------|---------------------|--------------------|

--- a/main.nf
+++ b/main.nf
@@ -81,9 +81,6 @@ if (!params.skip_alignment)     {
     if (params.protocol != 'DNA' && params.protocol != 'cDNA' && params.protocol != 'directRNA'){
       exit 1, "Invalid protocol option: ${params.protocl}. Valid options: 'DNA', 'cDNA', 'directRNA'"
     }
-    if (params.procol == 'directRNA'){
-      params.stranded = true
-    }
 }
 
 // TODO nf-core: Add in a check to see if running offline

--- a/main.nf
+++ b/main.nf
@@ -40,7 +40,7 @@ def helpMessage() {
 
     Alignment
       --protocol [str]                Specifies the type of data being inputted (DNA, cDNA or directRNA)
-      --stranded [bool]               Specifies if the inputted data is stranded (default: false, automatically true when using --protocol directRNA)
+      --stranded [bool]               Specifies if the data is strand-specific. Automatically activated when using --protocol directRNA (default: false)
       --aligner [str]                 Specifies the aligner to use (available are: graphmap or minimap2)
       --save_align_intermeds [bool]   Save the .sam files from the alignment step - not done by default
       --skip_alignment [bool]         Skip alignment and subsequent process

--- a/main.nf
+++ b/main.nf
@@ -39,7 +39,7 @@ def helpMessage() {
       --skip_demultiplexing [bool]    Skip basecalling and demultiplexing step with Guppy
 
     Alignment
-      --protocol [str]                Specifies the type of data being inputted (DNA, cDNA or directRNA)
+      --protocol [str]                Specifies the type of data that was sequenced i.e. "DNA", "cDNA" or "directRNA".
       --stranded [bool]               Specifies if the data is strand-specific. Automatically activated when using --protocol directRNA (default: false)
       --aligner [str]                 Specifies the aligner to use (available are: graphmap or minimap2)
       --save_align_intermeds [bool]   Save the .sam files from the alignment step - not done by default

--- a/main.nf
+++ b/main.nf
@@ -79,7 +79,7 @@ if (!params.skip_alignment)     {
         exit 1, "Invalid aligner option: ${params.aligner}. Valid options: 'minimap2', 'graphmap'"
     }
     if (params.protocol != 'DNA' && params.protocol != 'cDNA' && params.protocol != 'directRNA'){
-      exit 1, "Invalid protocol option: ${params.protocl}. Valid options: 'DNA', 'cDNA', 'directRNA'"
+      exit 1, "Invalid protocol option: ${params.protocol}. Valid options: 'DNA', 'cDNA', 'directRNA'"
     }
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -23,6 +23,8 @@ params {
   skip_demultiplexing = false
 
   // Options: Alignment
+  protocol = false
+  stranded = false
   aligner = 'minimap2'
   skip_alignment = false
   save_align_intermeds = false


### PR DESCRIPTION
Added the `--protocol` and `--stranded` flags.
Changed the `minimap2` alignment calls to work with this data - `graphmap2` (required for RNA) has less documentation so I will read up and submit in a future PR if that's cool?
At the moment I have tested the alignment with `directRNA`, `cDNA` and `stranded cDNA` data successfully.
Will need to update the tests to pass test suite.

Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs).

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/nanoseq branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/nanoseq)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [x] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [x] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/nanoseq/tree/master/.github/CONTRIBUTING.md
