### PR TITLE
Add BigBed file generation, Remove BEDGraph step, add skip params

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The pipeline is built using [Nextflow](https://www.nextflow.io), a workflow tool
 3. Alignment ([`GraphMap`](https://github.com/isovic/graphmap) or [`minimap2`](https://github.com/lh3/minimap2))
     * Each sample can be mapped to its own reference genome if multiplexed in this way
     * Convert `.sam` to co-ordinate sorted `.bam` and obtain mapping metrics ([`SAMtools`](http://www.htslib.org/doc/samtools.html))
-4. Create bigWig ([`BEDTools`](https://github.com/arq5x/bedtools2/), [`bedGraphToBigWig`](http://hgdownload.soe.ucsc.edu/admin/exe/)) and bigBed ([`BEDTools`](https://github.com/arq5x/bedtools2/), [`bedToBigBed`](http://hgdownload.soe.ucsc.edu/admin/exe/)) coverage tracks for visualisation
+4. Create `bigWig` ([`BEDTools`](https://github.com/arq5x/bedtools2/), [`bedGraphToBigWig`](http://hgdownload.soe.ucsc.edu/admin/exe/)) and `bigBed` ([`BEDTools`](https://github.com/arq5x/bedtools2/), [`bedToBigBed`](http://hgdownload.soe.ucsc.edu/admin/exe/)) coverage tracks for visualisation
 5. Present QC for alignment results ([`MultiQC`](https://multiqc.info/docs/))
 
 ## Quick Start

--- a/bin/scrape_software_versions.py
+++ b/bin/scrape_software_versions.py
@@ -10,7 +10,7 @@ regexes = {
     'guppy': ['guppy.version', r"Version (\S+)"],
     'pycoQC': ['pycoqc.version', r"pycoQC v(\S+)"],
     'NanoPlot': ['nanoplot.version', r"NanoPlot (\S+)"],
-    'NanoPlot': ['fastqc.version', r"FastQC v(\S+)"],
+    'NanoPlot': ['fastqc.version', r"FastQC (\S+)"],
     'GraphMap': ['graphmap.version', r"Version: v(\S+)"],
     'minimap2': ['minimap2.version', r"(\S+)"],
     'Samtools': ['samtools.version', r"samtools (\S+)"],

--- a/bin/scrape_software_versions.py
+++ b/bin/scrape_software_versions.py
@@ -10,7 +10,7 @@ regexes = {
     'guppy': ['guppy.version', r"Version (\S+)"],
     'pycoQC': ['pycoqc.version', r"pycoQC v(\S+)"],
     'NanoPlot': ['nanoplot.version', r"NanoPlot (\S+)"],
-    'NanoPlot': ['fastqc.version', r"FastQC (\S+)"],
+    'NanoPlot': ['fastqc.version', r"FastQC v(\S+)"],
     'GraphMap': ['graphmap.version', r"Version: v(\S+)"],
     'minimap2': ['minimap2.version', r"(\S+)"],
     'Samtools': ['samtools.version', r"samtools (\S+)"],

--- a/bin/scrape_software_versions.py
+++ b/bin/scrape_software_versions.py
@@ -10,6 +10,7 @@ regexes = {
     'guppy': ['guppy.version', r"Version (\S+)"],
     'pycoQC': ['pycoqc.version', r"pycoQC v(\S+)"],
     'NanoPlot': ['nanoplot.version', r"NanoPlot (\S+)"],
+    'NanoPlot': ['fastqc.version', r"FastQC v(\S+)"],
     'GraphMap': ['graphmap.version', r"Version: v(\S+)"],
     'minimap2': ['minimap2.version', r"(\S+)"],
     'Samtools': ['samtools.version', r"samtools (\S+)"],
@@ -23,6 +24,7 @@ results['Nextflow'] = '<span style="color:#999999;\">N/A</span>'
 results['guppy'] = '<span style="color:#999999;\">N/A</span>'
 results['pycoQC'] = '<span style="color:#999999;\">N/A</span>'
 results['NanoPlot'] = '<span style="color:#999999;\">N/A</span>'
+results['FastQC'] = '<span style="color:#999999;\">N/A</span>'
 results['GraphMap'] = '<span style="color:#999999;\">N/A</span>'
 results['minimap2'] = '<span style="color:#999999;\">N/A</span>'
 results['Samtools'] = '<span style="color:#999999;\">N/A</span>'

--- a/bin/scrape_software_versions.py
+++ b/bin/scrape_software_versions.py
@@ -10,7 +10,7 @@ regexes = {
     'guppy': ['guppy.version', r"Version (\S+)"],
     'pycoQC': ['pycoqc.version', r"pycoQC v(\S+)"],
     'NanoPlot': ['nanoplot.version', r"NanoPlot (\S+)"],
-    'NanoPlot': ['fastqc.version', r"FastQC v(\S+)"],
+    'FastQC': ['fastqc.version', r"FastQC v(\S+)"],
     'GraphMap': ['graphmap.version', r"Version: v(\S+)"],
     'minimap2': ['minimap2.version', r"(\S+)"],
     'Samtools': ['samtools.version', r"samtools (\S+)"],

--- a/conf/base.config
+++ b/conf/base.config
@@ -78,11 +78,12 @@ process {
   withName:SortBAM {
     container = 'quay.io/biocontainers/samtools:1.9--h8571acd_11'
   }
-  withName:BAMToBedGraph {
+  withName:BAMToBigWig {
     container = 'quay.io/biocontainers/bedtools:2.29.0--hc088bd4_3'
-  }
-  withName:BedGraphToBigWig {
     container = 'quay.io/biocontainers/ucsc-bedgraphtobigwig:357--h35c10e6_3'
+  }
+  withName:BAMToBigBed {
+    container = 'quay.io/biocontainers/bedtools:2.29.0--hc088bd4_3'
   }
   withName:output_documentation {
     container = 'quay.io/biocontainers/r-rmarkdown:0.9.5--r3.3.2_0'

--- a/conf/base.config
+++ b/conf/base.config
@@ -61,7 +61,7 @@ process {
     container = 'quay.io/biocontainers/nanoplot:1.26.3--py_0'
   }
   withName:FastQC {
-    container = 'quay.io/biocontainers/fastqc:0.11.7--6'
+    container = 'quay.io/biocontainers/fastqc:0.11.8--2'
   }
   withName:GetChromSizes {
       container = 'quay.io/biocontainers/samtools:1.9--h8571acd_11'

--- a/conf/base.config
+++ b/conf/base.config
@@ -78,12 +78,18 @@ process {
   withName:SortBAM {
     container = 'quay.io/biocontainers/samtools:1.9--h8571acd_11'
   }
-  withName:BAMToBigWig {
+  withName:BAMToBedGraph {
     container = 'quay.io/biocontainers/bedtools:2.29.0--hc088bd4_3'
+  }
+  withName:BedGraphToBigWig {
     container = 'quay.io/biocontainers/ucsc-bedgraphtobigwig:357--h35c10e6_3'
   }
-  withName:BAMToBigBed {
+  withName:BAMToBed12 {
     container = 'quay.io/biocontainers/bedtools:2.29.0--hc088bd4_3'
+  }
+  withName:Bed12ToBigBed {
+    container = 'quay.io/biocontainers/ucsc-bedtobigbed:357--h35c10e6_3'
+
   }
   withName:output_documentation {
     container = 'quay.io/biocontainers/r-rmarkdown:0.9.5--r3.3.2_0'

--- a/conf/base.config
+++ b/conf/base.config
@@ -60,6 +60,9 @@ process {
   withName:NanoPlotFastQ {
     container = 'quay.io/biocontainers/nanoplot:1.26.3--py_0'
   }
+  withName:FastQC {
+    container = 'quay.io/biocontainers/fastqc:0.11.7--6'
+  }
   withName:GetChromSizes {
       container = 'quay.io/biocontainers/samtools:1.9--h8571acd_11'
   }

--- a/conf/base.config
+++ b/conf/base.config
@@ -89,7 +89,6 @@ process {
   }
   withName:Bed12ToBigBed {
     container = 'quay.io/biocontainers/ucsc-bedtobigbed:357--h35c10e6_3'
-
   }
   withName:output_documentation {
     container = 'quay.io/biocontainers/r-rmarkdown:0.9.5--r3.3.2_0'

--- a/conf/base.config
+++ b/conf/base.config
@@ -64,7 +64,7 @@ process {
     container = 'quay.io/biocontainers/fastqc:0.11.8--2'
   }
   withName:GetChromSizes {
-      container = 'quay.io/biocontainers/samtools:1.9--h8571acd_11'
+    container = 'quay.io/biocontainers/samtools:1.9--h8571acd_11'
   }
   withName:MiniMap2Index {
     container = 'quay.io/biocontainers/minimap2:2.17--h84994c4_0'

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -267,7 +267,6 @@ Skip alignment and subsequent process
 | `--skip_bigwig`         | Skip BigWig file generation            |
 | `--skip_bigbed`         | Skip BigBed file generation            |
 
-
 ## Skipping QC steps
 
 The pipeline contains a number of quality control steps. Sometimes, it may not be desirable to run all of them if time and compute resources are limited.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -30,8 +30,7 @@
   * [`--aligner`](#--aligner)
   * [`--save_align_intermeds`](#--save_align_intermeds)
   * [`--skip_alignment`](#--skip_alignment)
-* [Visualisation file generation](#visualisation-file-generation)
-  * [`--skip_visualisation`](#--skip_visualisation)
+* [Coverage tracks](#coverage-tracks)
   * [`--skip_bigwig`](#--skip_bigwig)
   * [`--skip_bigbed`](#--skip_bigbed)
 * [Skipping QC steps](#skipping-qc-steps)
@@ -260,11 +259,10 @@ Save the `.sam` files from the alignment step - not done by default
 
 Skip alignment and subsequent process
 
-## Visualisation file generation
+## Coverage tracks
 
 | Step                    | Description                            |
 |-------------------------|----------------------------------------|
-| `--skip_visualisation`  | Skip BigBed and BigWig file generation |
 | `--skip_bigwig`         | Skip BigWig file generation            |
 | `--skip_bigbed`         | Skip BigBed file generation            |
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -38,6 +38,7 @@
   * [`--skip_qc`](#--skip_qc)
   * [`--skip_pycoqc`](#--skip_pycoqc)
   * [`--skip_nanoplot`](#--skip_nanoplot)
+  * [`--skip_fastqc`](#--skip_fastqc)
   * [`--skip_multiqc`](#--skip_multiqc)
 * [Job resources](#job-resources)
   * [Automatic resubmission](#automatic-resubmission)
@@ -277,6 +278,7 @@ The following options make this easy:
 | `--skip_qc`             | Skip all QC steps apart from MultiQC |
 | `--skip_pycoqc`         | Skip pycoQC                          |
 | `--skip_nanoplot`       | Skip NanoPlot                        |
+| `--skip_fastqc`         | Skip FastQC                          |
 | `--skip_multiqc`        | Skip MultiQC                         |
 
 ## Job resources

--- a/main.nf
+++ b/main.nf
@@ -445,8 +445,8 @@ process FastQC {
     script:
     """
     fastqc -q -t $task.cpus $fastq
-    mv ${fastq}_fastqc.html ${sample}_fastqc.html
-    mv ${fastq}_fastqc.zip ${sample}_fastqc.zip
+    mv ${fastq.baseName}_fastqc.html ${sample}_fastqc.html
+    mv ${fastq.baseName}_fastqc.zip ${sample}_fastqc.zip
     fastqc --version &> fastqc.version
     """
 }

--- a/main.nf
+++ b/main.nf
@@ -629,7 +629,8 @@ if (params.skip_alignment) {
         set file(fasta), file(sizes), val(sample), file(sam) from ch_align_sam
 
         output:
-        set file(fasta), file(sizes), val(sample), file("*.sorted.{bam,bam.bai}") into ch_sortbam_bed12, ch_sortbam_bedgraph
+        set file(fasta), file(sizes), val(sample), file("*.sorted.{bam,bam.bai}") into ch_sortbam_bed12,
+                                                                                       ch_sortbam_bedgraph
         file "*.{flagstat,idxstats,stats}" into ch_sortbam_stats_mqc
 
         script:
@@ -676,6 +677,8 @@ if (params.skip_alignment) {
             saveAs: { filename ->
                           if (filename.endsWith(".bigWig")) filename
                     }
+        when:
+        !params.skip_bigwig
 
         input:
         set file(fasta), file(sizes), val(sample), file(bedgraph) from ch_bedgraph
@@ -720,6 +723,9 @@ if (params.skip_alignment) {
             saveAs: { filename ->
                           if (filename.endsWith(".bigBed")) filename
                     }
+        when:
+        !params.skip_bigbed
+
         input:
         set file(fasta), file(sizes), val(sample), file(bed12) from ch_bed12
 
@@ -819,7 +825,7 @@ process MultiQC {
     input:
     file multiqc_config from ch_multiqc_config
     file ('samtools/*')  from ch_sortbam_stats_mqc.collect().ifEmpty([])
-    file ('fastqc/*')  from ch_fastqc_mqc.collect().ifEmpty([])
+    file ('fastqc/*')  from ch_fastq_mqc.collect().ifEmpty([])
     file ('software_versions/*') from software_versions_yaml.collect()
     file ('workflow_summary/*') from create_workflow_summary(summary)
 

--- a/main.nf
+++ b/main.nf
@@ -132,6 +132,7 @@ if (params.skip_visualisation) {
     params.skip_bigwig =  true
 }
 
+
 // Stage config files
 ch_multiqc_config = file(params.multiqc_config, checkIfExists: true)
 ch_output_docs = file("$baseDir/docs/output.md", checkIfExists: true)
@@ -181,6 +182,8 @@ if (!params.skip_alignment) {
     summary['Aligner']            = params.aligner
     summary['Save Intermeds']     = params.save_align_intermeds ? 'Yes' : 'No'
 }
+summary['Skip BigBed Generation'] = params.skip_bigbed ? 'Yes' : 'No'
+summary['Skip BigWig Generation'] = params.skip_bigwig ? 'Yes' : 'No'
 summary['Skip QC']                = params.skip_qc ? 'Yes' : 'No'
 summary['Skip pycoQC']            = params.skip_pycoqc ? 'Yes' : 'No'
 summary['Skip NanoPlot']          = params.skip_nanoplot ? 'Yes' : 'No'

--- a/main.nf
+++ b/main.nf
@@ -660,7 +660,7 @@ if (params.skip_alignment) {
 
         script:
         """
-        bamToBed -bed12 -cigar -i ${bam[0]} > ${sample}.bed12
+        bedtools bamtobed -bed12 -cigar -i ${bam[0]} > ${sample}.bed12
         bedtools sort -i ${sample}.bed12 > ${sample}.sorted.bed12
         bedToBigBed ${sample}.sorted.bed12 $sizes ${sample}.bb
         """

--- a/main.nf
+++ b/main.nf
@@ -445,8 +445,8 @@ process FastQC {
     script:
     """
     fastqc -q -t $task.cpus $fastq
-    mv ${fastq.baseName}_fastqc.html ${sample}_fastqc.html
-    mv ${fastq.baseName}_fastqc.zip ${sample}_fastqc.zip
+    mv ${fastq.simpleName}_fastqc.html ${sample}_fastqc.html
+    mv ${fastq.simpleName}_fastqc.zip ${sample}_fastqc.zip
     fastqc --version &> fastqc.version
     """
 }

--- a/main.nf
+++ b/main.nf
@@ -52,7 +52,7 @@ def helpMessage() {
       --save_align_intermeds [bool]   Save the .sam files from the alignment step (Default: false)
       --skip_alignment [bool]         Skip alignment and subsequent process (Default: false)
 
-    Visualisation
+    Coverage tracks
       --skip_bigwig [bool]            Skip BigWig file generation (Default: false)
       --skip_bigbed [bool]            Skip BigBed file generation (Default: false)
 

--- a/main.nf
+++ b/main.nf
@@ -133,6 +133,7 @@ if (params.skip_visualisation) {
 }
 
 
+
 // Stage config files
 ch_multiqc_config = file(params.multiqc_config, checkIfExists: true)
 ch_output_docs = file("$baseDir/docs/output.md", checkIfExists: true)
@@ -182,6 +183,7 @@ if (!params.skip_alignment) {
     summary['Aligner']            = params.aligner
     summary['Save Intermeds']     = params.save_align_intermeds ? 'Yes' : 'No'
 }
+summary['Skip Visualisation']     = params.skip_visualisation ? 'Yes' : 'No'
 summary['Skip BigBed Generation'] = params.skip_bigbed ? 'Yes' : 'No'
 summary['Skip BigWig Generation'] = params.skip_bigwig ? 'Yes' : 'No'
 summary['Skip QC']                = params.skip_qc ? 'Yes' : 'No'

--- a/main.nf
+++ b/main.nf
@@ -819,6 +819,7 @@ process MultiQC {
     input:
     file multiqc_config from ch_multiqc_config
     file ('samtools/*')  from ch_sortbam_stats_mqc.collect().ifEmpty([])
+    file ('fastqc/*')  from ch_fastqc_mqc.collect().ifEmpty([])
     file ('software_versions/*') from software_versions_yaml.collect()
     file ('workflow_summary/*') from create_workflow_summary(summary)
 
@@ -831,7 +832,8 @@ process MultiQC {
     rtitle = custom_runName ? "--title \"$custom_runName\"" : ''
     rfilename = custom_runName ? "--filename " + custom_runName.replaceAll('\\W','_').replaceAll('_+','_') + "_multiqc_report" : ''
     """
-    multiqc . -f $rtitle $rfilename --config $multiqc_config -m custom_content -m samtools
+    multiqc . -f $rtitle $rfilename --config $multiqc_config -m custom_content \
+    -m samtools -m fastqc
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -437,15 +437,14 @@ process FastQC {
     set val(fasta), val(sample), file(fastq) from ch_fastq_fastqc
 
     output:
-    file "*.{zip,html}"
+    file "*.{zip,html}" into ch_fastq_mqc
     file "*.version" into ch_fastqc_version
 
     script:
     """
-    fastqc -q -t $task.cpus $fastq
-    mv ${fastq.simpleName}_fastqc.html ${sample}_fastqc.html
-    mv ${fastq.simpleName}_fastqc.zip ${sample}_fastqc.zip
-    fastqc --version &> fastqc.version
+    [ ! -f  ${sample}.fastq.gz ] && ln -s $fastq ${sample}.fastq.gz
+    fastqc -q -t $task.cpus ${sample}.fastq.gz
+    fastqc --version > fastqc.version
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -54,8 +54,8 @@ def helpMessage() {
 
     Visualisation
       --skip_visualisation [bool]     Skip BigWig and BigBed file generation (Default: false)
-      --skip_bigbed [bool]            Skip BigBed file generation (Default: false)
       --skip_bigwig [bool]            Skip BigWig file generation (Default: false)
+      --skip_bigbed [bool]            Skip BigBed file generation (Default: false)
 
     QC
       --skip_qc [bool]                Skip all QC steps apart from MultiQC (Default: false)

--- a/main.nf
+++ b/main.nf
@@ -178,8 +178,8 @@ if (!params.skip_alignment) {
     summary['Save Intermeds']     = params.save_align_intermeds ? 'Yes' : 'No'
 }
 summary['Skip Visualisation']     = params.skip_visualisation ? 'Yes' : 'No'
-summary['Skip BigBed Generation'] = params.skip_bigbed ? 'Yes' : 'No'
-summary['Skip BigWig Generation'] = params.skip_bigwig ? 'Yes' : 'No'
+summary['Skip BigBed']            = params.skip_bigbed ? 'Yes' : 'No'
+summary['Skip BigWig']            = params.skip_bigwig ? 'Yes' : 'No'
 summary['Skip QC']                = params.skip_qc ? 'Yes' : 'No'
 summary['Skip pycoQC']            = params.skip_pycoqc ? 'Yes' : 'No'
 summary['Skip NanoPlot']          = params.skip_nanoplot ? 'Yes' : 'No'

--- a/main.nf
+++ b/main.nf
@@ -671,13 +671,11 @@ if (params.skip_alignment) {
         set file(fasta), file(sizes), val(sample), file(bam) from ch_sortbam_bed12
 
         output:
-        set file(fasta), file(sizes), val(sample), file("*.sorted.bed12") into ch_bed12
+        set file(fasta), file(sizes), val(sample), file("*.bed12") into ch_bed12
 
         script:
         """
-        bedtools bamtobed -bed12 -cigar -i ${bam[0]} > ${sample}.bed12
-        bedtools sort -i ${sample}.bed12 > ${sample}.sorted.bed12
-        bedToBigBed ${sample}.sorted.bed12 $sizes ${sample}.bb
+        bedtools bamtobed -bed12 -cigar -i ${bam[0]} | sort -k1,1 -k2,2n > ${sample}.bed12
         """
     }
 

--- a/main.nf
+++ b/main.nf
@@ -429,7 +429,7 @@ process FastQC {
     label 'process_medium'
     publishDir "${params.outdir}/fastqc", mode: 'copy',
         saveAs: { filename ->
-                      if (!filename.endsWith(".version")) filename
+                      filename.endsWith(".zip") ? "zips/$filename" : "$filename"
                 }
 
     when:
@@ -444,7 +444,7 @@ process FastQC {
 
     script:
     """
-    fastqc -t $task.cpus $fastq
+    fastqc -q -t $task.cpus $fastq
     fastqc --version &> fastqc.version
     """
 }

--- a/main.nf
+++ b/main.nf
@@ -437,7 +437,7 @@ process FastQC {
     set val(fasta), val(sample), file(fastq) from ch_fastq_fastqc
 
     output:
-    file "*.{zip,html}" into ch_fastq_mqc
+    file "*.{zip,html}" into ch_fastqc_mqc
     file "*.version" into ch_fastqc_version
 
     script:
@@ -825,7 +825,7 @@ process MultiQC {
     input:
     file multiqc_config from ch_multiqc_config
     file ('samtools/*')  from ch_sortbam_stats_mqc.collect().ifEmpty([])
-    file ('fastqc/*')  from ch_fastq_mqc.collect().ifEmpty([])
+    file ('fastqc/*')  from ch_fastqc_mqc.collect().ifEmpty([])
     file ('software_versions/*') from software_versions_yaml.collect()
     file ('workflow_summary/*') from create_workflow_summary(summary)
 

--- a/main.nf
+++ b/main.nf
@@ -656,7 +656,7 @@ if (params.skip_alignment) {
 }
 
 /*
- * STEP 10 - Output Description HTML
+ * STEP 11 - Output Description HTML
  */
 process output_documentation {
     publishDir "${params.outdir}/pipeline_info", mode: 'copy',
@@ -729,7 +729,7 @@ ${summary.collect { k,v -> "            <dt>$k</dt><dd><samp>${v ?: '<span style
 }
 
 /*
- * STEP 11 - MultiQC
+ * STEP 12 - MultiQC
  */
 process MultiQC {
     publishDir "${params.outdir}/multiqc", mode: 'copy'

--- a/main.nf
+++ b/main.nf
@@ -429,7 +429,7 @@ process FastQC {
     label 'process_medium'
     publishDir "${params.outdir}/fastqc", mode: 'copy',
         saveAs: { filename ->
-                      filename.endsWith(".zip") ? "zips/$filename" : "$filename"
+                      if (!filename.endsWith(".version")) filename
                 }
 
     when:
@@ -445,6 +445,8 @@ process FastQC {
     script:
     """
     fastqc -q -t $task.cpus $fastq
+    mv ${fastq}_fastqc.html ${sample}_fastqc.html
+    mv ${fastq}_fastqc.zip ${sample}_fastqc.zip
     fastqc --version &> fastqc.version
     """
 }

--- a/main.nf
+++ b/main.nf
@@ -444,7 +444,7 @@ process FastQC {
 
     script:
     """
-    fastqc -q -t $task.cpus $fastq
+    fastqc -t $task.cpus $fastq
     fastqc --version &> fastqc.version
     """
 }

--- a/main.nf
+++ b/main.nf
@@ -127,7 +127,7 @@ if (!params.skip_alignment) {
     }
 }
 
-if (params.skip_visualisation) {]
+if (params.skip_visualisation) {
     println("Worked but didn't change the params?")
     params.skip_bigbed = true
     params.skip_bigwig =  true

--- a/main.nf
+++ b/main.nf
@@ -127,9 +127,12 @@ if (!params.skip_alignment) {
     }
 }
 
-if (params.skip_visualisation) {
+if (params.skip_visualisation) {]
+    println("Worked but didn't change the params?")
     params.skip_bigbed = true
     params.skip_bigwig =  true
+} else {
+  println("No into statement")
 }
 
 

--- a/main.nf
+++ b/main.nf
@@ -53,7 +53,6 @@ def helpMessage() {
       --skip_alignment [bool]         Skip alignment and subsequent process (Default: false)
 
     Visualisation
-      --skip_visualisation [bool]     Skip BigWig and BigBed file generation (Default: false)
       --skip_bigwig [bool]            Skip BigWig file generation (Default: false)
       --skip_bigbed [bool]            Skip BigBed file generation (Default: false)
 
@@ -177,7 +176,6 @@ if (!params.skip_alignment) {
     summary['Aligner']            = params.aligner
     summary['Save Intermeds']     = params.save_align_intermeds ? 'Yes' : 'No'
 }
-summary['Skip Visualisation']     = params.skip_visualisation ? 'Yes' : 'No'
 summary['Skip BigBed']            = params.skip_bigbed ? 'Yes' : 'No'
 summary['Skip BigWig']            = params.skip_bigwig ? 'Yes' : 'No'
 summary['Skip QC']                = params.skip_qc ? 'Yes' : 'No'
@@ -654,7 +652,7 @@ if (params.skip_alignment) {
         label 'process_medium'
 
         when:
-        !params.skip_alignment && !params.skip_bigwig
+        !params.skip_bigwig
         input:
         set file(fasta), file(sizes), val(sample), file(bam) from ch_sortbam_bedgraph
 
@@ -700,7 +698,7 @@ if (params.skip_alignment) {
         label 'process_medium'
 
         when:
-        !params.skip_visualisation && !params.skip_bigbed
+        !params.skip_bigbed
         input:
         set file(fasta), file(sizes), val(sample), file(bam) from ch_sortbam_bed12
 
@@ -721,17 +719,17 @@ if (params.skip_alignment) {
         label 'process_medium'
         publishDir path: "${params.outdir}/${params.aligner}/bigbed/", mode: 'copy',
             saveAs: { filename ->
-                          if (filename.endsWith(".bb")) filename
+                          if (filename.endsWith(".bigBed")) filename
                     }
         input:
         set file(fasta), file(sizes), val(sample), file(bed12) from ch_bed12
 
         output:
-        set file(fasta), file(sizes), val(sample), file("*.bb") into ch_bigbed
+        set file(fasta), file(sizes), val(sample), file("*.bigBed") into ch_bigbed
 
         script:
         """
-        bedToBigBed $bed12 $sizes ${sample}.bb
+        bedToBigBed $bed12 $sizes ${sample}.bigBed
         """
     }
 }

--- a/main.nf
+++ b/main.nf
@@ -425,7 +425,7 @@ process NanoPlotFastQ {
  * STEP 5 - FastQ QC using FastQC
  */
 process FastQC {
-    tag "$name"
+    tag "$sample"
     label 'process_medium'
     publishDir "${params.outdir}/fastqc", mode: 'copy',
         saveAs: { filename ->

--- a/nextflow.config
+++ b/nextflow.config
@@ -32,7 +32,6 @@ params {
   skip_alignment = false
 
   // Options: Visualisation
-  skip_visualisation = false
   skip_bigbed = false
   skip_bigwig = false
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -40,6 +40,7 @@ params {
   skip_qc = false
   skip_pycoqc = false
   skip_nanoplot = false
+  skip_fastqc = false
   skip_multiqc = false
 
   // Options: AWSBatch

--- a/nextflow.config
+++ b/nextflow.config
@@ -31,6 +31,11 @@ params {
   save_align_intermeds = false
   skip_alignment = false
 
+  // Options: Visualisation
+  skip_visualisation = false
+  skip_bigbed = false
+  skip_bigwig = false
+
   // Options: QC
   skip_qc = false
   skip_pycoqc = false


### PR DESCRIPTION
Hello, a few changes for the downstream file generation:
- Merged `BAMToBed12` and `Bed12ToBigWig` into one process `BAMToBigWig`
- No saving of `BEDGraph` file to output dir
- Added `BAMToBigBed` Process
- Added params for skipping these processes (each case has been tested)
   `--skip_visualisation` (maybe `--skip_vis` is better)
    `--skip_bigbed` 
    `--skipbigwig`
- Updated docs etc. to reflect these changes

Many thanks for contributing to nf-core/nanoseq!

Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs).

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [x] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/nanoseq branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/nanoseq)
 - [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [x] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated



**Learn more about contributing:** https://github.com/nf-core/nanoseq/tree/master/.github/CONTRIBUTING.md
