### PR TITLE
add -split to genomeCoverageBed

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -687,8 +687,9 @@ if (params.skip_alignment) {
         file "*.version" into ch_bedtools_version
 
         script:
+        split = (params.protocol == 'DNA') ? "" : "-split"
         """
-        genomeCoverageBed -split -ibam ${bam[0]} -bg | sort -k1,1 -k2,2n >  ${sample}.bedGraph
+        genomeCoverageBed $split -ibam ${bam[0]} -bg | sort -k1,1 -k2,2n >  ${sample}.bedGraph
         bedtools --version > bedtools.version
         """
     }

--- a/main.nf
+++ b/main.nf
@@ -688,7 +688,7 @@ if (params.skip_alignment) {
 
         script:
         """
-        genomeCoverageBed -ibam ${bam[0]} -bg | sort -k1,1 -k2,2n >  ${sample}.bedGraph
+        genomeCoverageBed -split -ibam ${bam[0]} -bg | sort -k1,1 -k2,2n >  ${sample}.bedGraph
         bedtools --version > bedtools.version
         """
     }


### PR DESCRIPTION
We need the `-split` flag or else we get bigwig files with coverage across introns like below:
![image](https://user-images.githubusercontent.com/37123979/70308682-c3348d80-1846-11ea-8aac-64cd570471ed.png)
Very small PR but without this flag, the bigWig coverage track is not useful for RNA/cDNA.
I don't know what the protocol is for DNA (I know `-split` is not used in CHIP-seq) but I suspect `-split` may be needed to view deletions. If not it's super easy for me to fix it up 😀 
## PR checklist
 - [ ] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/nanoseq branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/nanoseq)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/nanoseq/tree/master/.github/CONTRIBUTING.md
