### PR TITLE
Updated m6anet to 2.0.2

### DIFF
--- a/modules/local/m6anet_dataprep.nf
+++ b/modules/local/m6anet_dataprep.nf
@@ -3,7 +3,9 @@ process M6ANET_DATAPREP {
     label 'process_medium'
 
 //  conda     (params.enable_conda ? "bioconda::nanopolish==0.13.2" : null) // need to get xpore onto conda
-    container "docker.io/yuukiiwa/m6anet:1.0"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/m6anet:2.0.2--pyhdfd78af_0' :
+        'quay.io/biocontainers/m6anet:2.0.2--pyhdfd78af_0' }"
 
     input:
     tuple val(meta), path(genome), path(gtf), path(eventalign), path(nanopolish_summary)
@@ -17,14 +19,14 @@ process M6ANET_DATAPREP {
 
     script:
     """
-    m6anet-dataprep \\
+    m6anet dataprep \\
     --eventalign $eventalign \\
     --out_dir $meta.id \\
     --n_processes $task.cpus
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        m6anet: \$( echo 'm6anet 1.0' )
+        m6anet: \$( echo 'm6anet 2.0.2' )
     END_VERSIONS
     """
 }

--- a/modules/local/m6anet_inference.nf
+++ b/modules/local/m6anet_inference.nf
@@ -4,7 +4,9 @@ process M6ANET_INFERENCE {
     label 'process_medium'
 
 //  conda     (params.enable_conda ? "bioconda::nanopolish==0.13.2" : null) // need to get xpore onto conda
-    container "docker.io/yuukiiwa/m6anet:1.0"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/m6anet:2.0.2--pyhdfd78af_0' :
+        'quay.io/biocontainers/m6anet:2.0.2--pyhdfd78af_0' }"
 
     input:
     tuple val(meta), path(input_dir)
@@ -19,11 +21,11 @@ process M6ANET_INFERENCE {
     script:
     def out_dir = meta.id+"_results"
     """
-    m6anet-run_inference --input_dir $input_dir --out_dir $out_dir  --batch_size 512 --n_processes $task.cpus --num_iterations 5 --device cpu
+    m6anet inference --input_dir $input_dir --out_dir $out_dir  --batch_size 512 --n_processes $task.cpus --num_iterations 5 --device cpu
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        m6anet: \$( echo 'm6anet 1.0' )
+        m6anet: \$( echo 'm6anet 2.0.2' )
     END_VERSIONS
     """
 }


### PR DESCRIPTION
With the updated biocontainer for m6anet being built, can update the singularity and docker container with the latest version.

This version changed how m6anet is called.  It has `m6anet` and the analysis as a parameter (`inference`, `dataprep`) instead of `m6anet-run_inference` and `m6anet-dataprep` commands.

There are now two files for output from `m6anet inference`, but the existing output of '*' captures those.  In the future, might be nice to specify these individually and emit them as separate outputs for downstream analysis.

<!--
# nf-core/nanoseq pull request

Many thanks for contributing to nf-core/nanoseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/nanoseq/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ✅ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/nanoseq/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/nanoseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
